### PR TITLE
feat: add prompt generator for contract methods

### DIFF
--- a/frontend/components/Execution/MethodExecutor.tsx
+++ b/frontend/components/Execution/MethodExecutor.tsx
@@ -5,6 +5,7 @@ import { Play, Settings } from 'lucide-react';
 import { useIDEStore, File, ContractInstance } from '@/store/ide-store';
 import { contractsApi } from '@/lib/api';
 import { parseContractMethods, MethodDefinition } from '@/utils/contractParser';
+import { generateFrontendPrompt } from '@/utils/promptGenerator';
 
 interface MethodExecutorProps {
   blueprintId?: string;
@@ -78,6 +79,21 @@ export const MethodExecutor: React.FC<MethodExecutorProps> = ({ blueprintId }) =
       blueprint_1: '3cb032600bdf7db784800e4ea911b10676fa2f67591f82bb62628c234e771595',
       blueprint_2: '4dc143711cef8ec895911f5fb822c21787fa3f78502f93cc73739d345f882606',
     },
+  };
+
+  const handleGeneratePrompt = () => {
+    if (!activeFile) {
+      addConsoleMessage('error', 'No contract file loaded.');
+      return;
+    }
+    if (methodDefinitions.length === 0) {
+      addConsoleMessage('error', 'No methods found to generate prompt.');
+      return;
+    }
+    const prompt = generateFrontendPrompt(activeFile.name.replace('.py', ''), methodDefinitions);
+    navigator.clipboard.writeText(prompt)
+      .then(() => addConsoleMessage('success', 'Prompt copied to clipboard'))
+      .catch((err) => addConsoleMessage('error', `Failed to copy prompt: ${err}`));
   };
 
 
@@ -255,7 +271,15 @@ export const MethodExecutor: React.FC<MethodExecutorProps> = ({ blueprintId }) =
   return (
     <div className="h-full bg-gray-800 border-r border-gray-700 p-4 overflow-y-auto">
       <div className="flex flex-col gap-4">
-        <h3 className="text-lg font-semibold text-white mb-2">Contract Methods</h3>
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-lg font-semibold text-white">Contract Methods</h3>
+          <button
+            onClick={handleGeneratePrompt}
+            className="px-2 py-1 text-sm bg-purple-600 hover:bg-purple-700 text-white rounded"
+          >
+            Generate Prompt
+          </button>
+        </div>
         {contractInstance && (
           <div className="bg-green-900/30 border border-green-700 rounded p-2 text-sm">
             <span className="text-green-400">✅ Contract Initialized</span>

--- a/frontend/utils/promptGenerator.ts
+++ b/frontend/utils/promptGenerator.ts
@@ -1,0 +1,19 @@
+import { MethodDefinition } from './contractParser';
+
+/**
+ * Generate a frontend prompt for the given contract methods
+ */
+export function generateFrontendPrompt(contractName: string, methods: MethodDefinition[]): string {
+  let prompt = `You are an expert dApp frontend developer. Build a complete user interface for the Hathor nano-contract blueprint "${contractName}".\n`;
+  prompt += 'The blueprint exposes the following methods:\n';
+
+  methods.forEach(method => {
+    const params = method.parameters.map(p => `${p.name}: ${p.type}`).join(', ');
+    const returnType = method.returnType ? ` -> ${method.returnType}` : '';
+    prompt += `\n${method.decorator.toUpperCase()} ${method.name}(${params})${returnType}\n${method.description}`;
+  });
+
+  prompt += '\n\nCreate a frontend that allows users to call all public methods and read data through view methods.';
+  prompt += ' Use appropriate forms for parameters and display returned data.\n';
+  return prompt;
+}


### PR DESCRIPTION
## Summary
- add utility to build LLM prompts describing contract methods
- expose "Generate Prompt" button in MethodExecutor to copy prompt to clipboard

## Testing
- `npm run lint` (prompts for ESLint configuration)
- `npm run type-check` (fails: lib/pyodide-runner.ts TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68ad1524cd288321b215c6c74bf7b941