### PR TITLE
Add Playwright smoke tests for frontend

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 .next/
+playwright-report/
+test-results/

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -10,8 +10,13 @@ const api = axios.create({
   },
 });
 
+// Enable a lightweight mock implementation for e2e tests when
+// NEXT_PUBLIC_PYODIDE_MOCK is set. This avoids downloading the full
+// Pyodide runtime and large Hathor modules during Playwright runs.
+const IS_PYODIDE_MOCK = process.env.NEXT_PUBLIC_PYODIDE_MOCK === 'true';
+
 // Flag to determine if we should use browser-based execution
-const USE_BROWSER_EXECUTION = true;
+const USE_BROWSER_EXECUTION = !IS_PYODIDE_MOCK;
 
 export interface CompileRequest {
   code: string;
@@ -79,6 +84,16 @@ export interface StorageInfo {
 
 export const contractsApi = {
   compile: async (request: CompileRequest): Promise<CompileResponse> => {
+    if (IS_PYODIDE_MOCK) {
+      return {
+        success: true,
+        blueprint_id: 'mock-blueprint',
+        errors: [],
+        warnings: [],
+        gas_estimate: 0,
+      };
+    }
+
     if (USE_BROWSER_EXECUTION) {
       // Use browser-based Pyodide execution
       await pyodideRunner.initialize();
@@ -103,6 +118,16 @@ export const contractsApi = {
   },
 
   execute: async (request: ExecuteRequest): Promise<ExecuteResponse> => {
+    if (IS_PYODIDE_MOCK) {
+      return {
+        success: true,
+        result: null,
+        gas_used: 0,
+        logs: [],
+        state_changes: {},
+      };
+    }
+
     if (USE_BROWSER_EXECUTION) {
       // Use browser-based Pyodide execution
       await pyodideRunner.initialize();
@@ -180,6 +205,10 @@ export const contractsApi = {
 
 export const validationApi = {
   validate: async (request: ValidationRequest): Promise<ValidationResponse> => {
+    if (IS_PYODIDE_MOCK) {
+      return { valid: true, errors: [], suggestions: [] };
+    }
+
     if (USE_BROWSER_EXECUTION) {
       // Use browser-based validation
       await pyodideRunner.initialize();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start -H 0.0.0.0",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "playwright test"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+  webServer: {
+    command: 'NEXT_PUBLIC_PYODIDE_MOCK=true npm run dev',
+    url: 'http://localhost:3000',
+    timeout: 120000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/frontend/tests/ide.spec.ts
+++ b/frontend/tests/ide.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from 'playwright/test';
+
+// Basic smoke tests for the Nano Contracts IDE
+
+test.describe('Nano Contracts IDE', () => {
+  test('loads default contracts and toolbar buttons', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText('SimpleCounter.py')).toBeVisible();
+    await expect(page.getByText('LiquidityPool.py')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Compile' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Quick Execute' })).toBeVisible();
+  });
+
+  test('switching files updates the editor content', async ({ page }) => {
+    await page.goto('/');
+    await page.getByText('LiquidityPool.py').click();
+    await expect(page.locator('.monaco-editor')).toContainText('class LiquidityPool');
+    await page.getByText('SimpleCounter.py').click();
+    await expect(page.locator('.monaco-editor')).toContainText('class SimpleCounter');
+  });
+
+  test('compiling shows success message in console', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Compile' }).click();
+    await expect(page.locator('text=Successfully compiled')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright config and IDE smoke tests
- allow mocking Pyodide initialization via `NEXT_PUBLIC_PYODIDE_MOCK`
- stub API methods when Pyodide is mocked
- ignore Playwright artefacts in frontend

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npx playwright install chromium` *(fails: Download failed: server returned code 403 body 'Forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68ad2d9287108321a09ad1fe26980863