### PR TITLE
feat: add prompt editor modal for frontend integration

### DIFF
--- a/backend/api/frontend_prompt.py
+++ b/backend/api/frontend_prompt.py
@@ -1,0 +1,61 @@
+import structlog
+from fastapi import APIRouter
+from pydantic import BaseModel
+from typing import List, Optional
+
+logger = structlog.get_logger()
+router = APIRouter()
+
+
+class MethodParameter(BaseModel):
+    name: str
+    type: str
+
+
+class MethodDefinition(BaseModel):
+    name: str
+    decorator: str
+    description: str | None = None
+    parameters: List[MethodParameter]
+    return_type: Optional[str] = None
+
+
+class PromptRequest(BaseModel):
+    contract_name: str
+    methods: List[MethodDefinition]
+
+
+class PromptResponse(BaseModel):
+    prompt: str
+
+
+HATHOR_GUIDE = """
+Frontend integration guide for Hathor:
+1. Use WalletConnect to establish a session with a Hathor-compatible wallet (mobile or browser).
+2. Once connected, send RPC requests through the provider. To execute `@public` nano-contract methods, call `htr_sendNanoContractTx` with the contract id, method name, arguments, and required tokens so the wallet can sign and broadcast the transaction.
+3. For `@view` methods, invoke the appropriate read-only RPC without signing to query state.
+4. Always handle token decimals (last two digits are decimals) and ensure IDs such as TokenUid or ContractId are 64 hex chars.
+See the official documentation for details: https://docs.hathor.network/references/sdk/dapp/wallet-integration-development
+"""
+
+
+@router.post("/prompt", response_model=PromptResponse)
+async def generate_frontend_prompt(req: PromptRequest) -> PromptResponse:
+    parts: List[str] = []
+    parts.append(
+        f"You are an expert dApp frontend developer. Build a UI for the Hathor nano-contract blueprint \"{req.contract_name}\"."
+    )
+    parts.append("The blueprint exposes the following methods:")
+    for m in req.methods:
+        params = ", ".join(f"{p.name}: {p.type}" for p in m.parameters)
+        ret = f" -> {m.return_type}" if m.return_type else ""
+        parts.append(f"\n{m.decorator.upper()} {m.name}({params}){ret}")
+        if m.description:
+            parts.append(m.description)
+    parts.append(
+        "\nUse WalletConnect to integrate these methods with a Hathor wallet. Follow this guide:\n"
+        + HATHOR_GUIDE
+    )
+    prompt = "\n".join(parts)
+    logger.info("Generated frontend prompt", contract=req.contract_name)
+    return PromptResponse(prompt=prompt)

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 import structlog
 
 from api.ai_assistant import router as ai_assistant_router
+from api.frontend_prompt import router as frontend_prompt_router
 
 # Load environment variables from .env file
 load_dotenv()
@@ -58,6 +59,9 @@ app.add_middleware(
 # Include routers
 app.include_router(
     ai_assistant_router, prefix="/api/ai", tags=["ai-assistant"]
+)
+app.include_router(
+    frontend_prompt_router, prefix="/api/frontend", tags=["frontend"]
 )
 
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -16,9 +16,13 @@ sys.path.append(str(ROOT_DIR))
 api_module = types.ModuleType("api")
 ai_module = types.ModuleType("api.ai_assistant")
 ai_module.router = APIRouter()
+frontend_module = types.ModuleType("api.frontend_prompt")
+frontend_module.router = APIRouter()
 api_module.ai_assistant = ai_module
+api_module.frontend_prompt = frontend_module
 sys.modules.setdefault("api", api_module)
 sys.modules.setdefault("api.ai_assistant", ai_module)
+sys.modules.setdefault("api.frontend_prompt", frontend_module)
 
 from main import app  # noqa: E402
 

--- a/frontend/components/Execution/PromptEditorModal.tsx
+++ b/frontend/components/Execution/PromptEditorModal.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React from 'react';
+import { X } from 'lucide-react';
+
+interface PromptEditorModalProps {
+  isOpen: boolean;
+  prompt: string;
+  isLoading: boolean;
+  onChange: (value: string) => void;
+  onClose: () => void;
+  onCopy: () => void;
+  onExport: () => void;
+}
+
+export const PromptEditorModal: React.FC<PromptEditorModalProps> = ({
+  isOpen,
+  prompt,
+  isLoading,
+  onChange,
+  onClose,
+  onCopy,
+  onExport,
+}) => {
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-gray-800 rounded shadow-lg w-full max-w-2xl p-4">
+        <div className="flex justify-between items-center mb-2">
+          <h2 className="text-white text-lg font-semibold">Prompt Editor</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-white">
+            <X size={20} />
+          </button>
+        </div>
+        {isLoading ? (
+          <div className="text-center text-gray-300 p-8">Generating prompt...</div>
+        ) : (
+          <textarea
+            className="w-full h-64 p-2 bg-gray-700 text-white rounded mb-4"
+            value={prompt}
+            onChange={(e) => onChange(e.target.value)}
+          />
+        )}
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onExport}
+            className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded"
+            disabled={isLoading}
+          >
+            Export to Lovable
+          </button>
+          <button
+            onClick={onCopy}
+            className="px-3 py-1 bg-purple-600 hover:bg-purple-700 text-white rounded"
+            disabled={isLoading}
+          >
+            Copy to Clipboard
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PromptEditorModal;

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { pyodideRunner } from './pyodide-runner';
+import type { MethodDefinition } from '@/utils/contractParser';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
@@ -175,6 +176,19 @@ export const contractsApi = {
       const response = await api.get(`/api/contracts/${contractId}/state`);
       return response.data;
     }
+  },
+};
+
+export const promptApi = {
+  generatePrompt: async (
+    contractName: string,
+    methods: MethodDefinition[]
+  ): Promise<string> => {
+    const response = await api.post('/api/frontend/prompt', {
+      contract_name: contractName,
+      methods,
+    });
+    return response.data.prompt;
   },
 };
 

--- a/frontend/store/ide-store.ts
+++ b/frontend/store/ide-store.ts
@@ -42,6 +42,9 @@ interface IDEState {
   chatSessions: ChatSession[];
   activeChatSessionId: string | null;
 
+  // Frontend prompt
+  frontendPrompt: string;
+
   // UI State
   isCompiling: boolean;
   isExecuting: boolean;
@@ -70,6 +73,8 @@ interface IDEState {
   getChatSession: (id: string) => ChatSession | null;
   setActiveChatSession: (id: string) => void;
   deleteChatSession: (id: string) => void;
+
+  setFrontendPrompt: (prompt: string) => void;
 
   // Storage operations
   initializeStore: () => Promise<void>;
@@ -239,6 +244,7 @@ __blueprint__ = LiquidityPool`,
 
   chatSessions: [],
   activeChatSessionId: null,
+  frontendPrompt: '',
 
   isCompiling: false,
   isExecuting: false,
@@ -427,6 +433,14 @@ __blueprint__ = LiquidityPool`,
     }
   },
 
+  setFrontendPrompt: (prompt) => {
+    set(() => ({ frontendPrompt: prompt }));
+    const state = get();
+    if (state.isStorageInitialized) {
+      storage.setPreference('frontendPrompt', prompt).catch(console.error);
+    }
+  },
+
   // Storage operations
   initializeStore: async () => {
     try {
@@ -437,6 +451,8 @@ __blueprint__ = LiquidityPool`,
       const state = get();
       await state.loadFilesFromStorage();
       await state.loadChatSessionsFromStorage();
+      const savedPrompt = await storage.getPreference('frontendPrompt', '');
+      set({ frontendPrompt: savedPrompt });
 
       console.log('IDE store initialized with persistent storage');
     } catch (error) {


### PR DESCRIPTION
## Summary
- add backend endpoint to generate frontend prompt with Hathor wallet integration details
- introduce prompt editor modal with export to Lovable and copy features
- persist edited prompt in IDE store
- update integration guide to use WalletConnect and `htr_sendNanoContractTx`

## Testing
- `pytest`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68aee0372ba883219f5f8d172aa89a46