### PR TITLE
feat(frontend): add blueprint walkthrough UI

### DIFF
--- a/frontend/app/walkthrough/page.tsx
+++ b/frontend/app/walkthrough/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { Walkthrough } from '@/components/Walkthrough/Walkthrough';
+
+export default function WalkthroughPage() {
+  return (
+    <div className="h-screen">
+      <Walkthrough />
+    </div>
+  );
+}

--- a/frontend/components/Walkthrough/Walkthrough.tsx
+++ b/frontend/components/Walkthrough/Walkthrough.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import React from 'react';
+import { useIDEStore } from '@/store/ide-store';
+import { contractsApi } from '@/lib/api';
+import { steps, Step } from './steps';
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import { CodeEditor } from '@/components/Editor/CodeEditor';
+import { Console } from '@/components/Console/Console';
+
+export function Walkthrough() {
+  const { files, activeFileId, addConsoleMessage, initializeStore } = useIDEStore();
+  const activeFile = files.find(f => f.id === activeFileId);
+  const [stepIndex, setStepIndex] = React.useState(0);
+  const [isRunning, setIsRunning] = React.useState(false);
+  const [finalBlueprintId, setFinalBlueprintId] = React.useState<string>('');
+
+  const currentStep: Step | undefined = steps[stepIndex];
+
+  React.useEffect(() => {
+    initializeStore();
+  }, [initializeStore]);
+
+  const runTest = async () => {
+    if (!activeFile || !currentStep) return;
+    setIsRunning(true);
+    addConsoleMessage('info', `Testing step ${stepIndex + 1}: ${currentStep.title}`);
+    try {
+      const result = await contractsApi.compile({
+        code: activeFile.content,
+        blueprint_name: activeFile.name.replace('.py', ''),
+      });
+      if (!result.success || !result.blueprint_id) {
+        addConsoleMessage('error', 'Compilation failed');
+        setIsRunning(false);
+        return;
+      }
+      const passed = await currentStep.test({
+        code: activeFile.content,
+        blueprintId: result.blueprint_id,
+      });
+      if (passed) {
+        addConsoleMessage('success', `Step ${stepIndex + 1} passed`);
+        setStepIndex(stepIndex + 1);
+      } else {
+        addConsoleMessage('warning', 'Step requirements not met');
+      }
+    } catch (err: any) {
+      addConsoleMessage('error', `Test error: ${err.message}`);
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  React.useEffect(() => {
+    if (!currentStep && activeFile && !finalBlueprintId) {
+      const compile = async () => {
+        const result = await contractsApi.compile({
+          code: activeFile.content,
+          blueprint_name: activeFile.name.replace('.py', ''),
+        });
+        if (result.success && result.blueprint_id) {
+          setFinalBlueprintId(result.blueprint_id);
+        } else {
+          addConsoleMessage('error', 'Compilation failed');
+        }
+      };
+      compile();
+    }
+  }, [currentStep, activeFile, finalBlueprintId, addConsoleMessage]);
+
+  const copyBlueprint = () => {
+    if (!activeFile) return;
+    navigator.clipboard
+      .writeText(activeFile.content)
+      .then(() => addConsoleMessage('success', 'Blueprint code copied to clipboard'))
+      .catch(err => addConsoleMessage('error', `Failed to copy blueprint: ${err.message}`));
+  };
+
+  const copyBlueprintId = () => {
+    if (!finalBlueprintId) return;
+    navigator.clipboard
+      .writeText(finalBlueprintId)
+      .then(() => addConsoleMessage('success', 'Blueprint ID copied to clipboard'))
+      .catch(err => addConsoleMessage('error', `Failed to copy blueprint ID: ${err.message}`));
+  };
+
+  if (!currentStep) {
+    return (
+      <div className="h-full bg-gray-900 p-4 text-white space-y-4">
+        <h2 className="text-xl font-bold">Congratulations!</h2>
+        <p>You have finished building the Crowdfund blueprint. Your blueprint ID is:</p>
+        {finalBlueprintId && (
+          <p className="break-all font-mono">{finalBlueprintId}</p>
+        )}
+        <div className="flex space-x-2">
+          <button
+            onClick={copyBlueprintId}
+            className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded"
+          >
+            Copy Blueprint ID
+          </button>
+          <button
+            onClick={copyBlueprint}
+            className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded"
+          >
+            Copy Blueprint Code
+          </button>
+        </div>
+        <pre className="bg-gray-800 p-2 rounded text-sm overflow-auto max-h-96">
+{activeFile?.content}
+</pre>
+        <p className="text-sm">
+          During the beta phase of nano contracts the Hathor team is reviewing all
+          blueprint code that is deployed to the network. You can send it to
+          <a href="mailto:pedro@hathor.network" className="underline ml-1 mr-1">
+            pedro@hathor.network
+          </a>
+          or create a pull request to
+          <a
+            href="https://github.com/hathornetwork/hathor-core"
+            className="underline ml-1"
+          >
+            github.com/hathornetwork/hathor-core
+          </a>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-gray-900 text-white">
+      <PanelGroup direction="horizontal" className="flex-1">
+        <Panel defaultSize={30} minSize={20} className="p-4 space-y-4">
+          <h2 className="text-xl font-bold">Step {stepIndex + 1}: {currentStep.title}</h2>
+          <p>{currentStep.description}</p>
+          <button
+            onClick={runTest}
+            disabled={isRunning}
+            className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded"
+          >
+            {isRunning ? 'Running...' : 'Run Step Test'}
+          </button>
+        </Panel>
+
+        <PanelResizeHandle className="w-1 bg-gray-800 hover:bg-blue-600 transition-colors" />
+
+        <Panel defaultSize={70}>
+          <PanelGroup direction="vertical" className="h-full">
+            <Panel defaultSize={70}>
+              <CodeEditor />
+            </Panel>
+
+            <PanelResizeHandle className="h-1 bg-gray-800 hover:bg-blue-600 transition-colors" />
+
+            <Panel defaultSize={30} minSize={15}>
+              <Console />
+            </Panel>
+          </PanelGroup>
+        </Panel>
+      </PanelGroup>
+    </div>
+  );
+}

--- a/frontend/components/Walkthrough/steps.ts
+++ b/frontend/components/Walkthrough/steps.ts
@@ -1,0 +1,99 @@
+import { contractsApi } from '@/lib/api';
+
+export interface Step {
+  title: string;
+  description: string;
+  test: (ctx: { code: string; blueprintId: string }) => boolean | Promise<boolean>;
+}
+
+export const steps: Step[] = [
+  {
+    title: 'Define contract structure',
+    description:
+      'Create a Crowdfund blueprint with imports, class declaration, and basic state variables like owner, goal, and deadline.',
+    test: async ({ code }) =>
+      code.includes('class Crowdfund(Blueprint)') &&
+      code.includes('owner: Address') &&
+      code.includes('goal: int') &&
+      code.includes('deadline: int'),
+  },
+  {
+    title: 'Initialize campaign',
+    description:
+      'Add a @public initialize method that sets owner, goal, deadline and initializes storage for contributions.',
+    test: async ({ blueprintId }) => {
+      const init = await contractsApi.execute({
+        contract_id: blueprintId,
+        method_name: 'initialize',
+        args: [100, 123456],
+      });
+      return init.success && Boolean(init.result?.contract_id);
+    },
+  },
+  {
+    title: 'Accept contributions',
+    description:
+      'Implement a @public(allow_deposit=True) contribute method that records deposits per address and updates the total raised.',
+    test: async ({ blueprintId }) => {
+      const init = await contractsApi.execute({
+        contract_id: blueprintId,
+        method_name: 'initialize',
+        args: [100, 123456],
+      });
+      if (!init.success || !init.result?.contract_id) return false;
+      const contribute = await contractsApi.execute({
+        contract_id: init.result.contract_id,
+        method_name: 'contribute',
+        args: [],
+      });
+      return contribute.success || Boolean(contribute.error);
+    },
+  },
+  {
+    title: 'Finalize or refund',
+    description:
+      'Add a finalize method with @public(allow_withdrawal=True) that lets the owner withdraw when goal is reached or contributors refund otherwise.',
+    test: async ({ blueprintId }) => {
+      const init = await contractsApi.execute({
+        contract_id: blueprintId,
+        method_name: 'initialize',
+        args: [100, 123456],
+      });
+      if (!init.success || !init.result?.contract_id) return false;
+      const finalize = await contractsApi.execute({
+        contract_id: init.result.contract_id,
+        method_name: 'finalize',
+        args: [],
+      });
+      return finalize.success || Boolean(finalize.error);
+    },
+  },
+  {
+    title: 'Expose views',
+    description:
+      'Provide view methods like get_total and get_contribution to query contract state.',
+    test: async ({ blueprintId }) => {
+      const init = await contractsApi.execute({
+        contract_id: blueprintId,
+        method_name: 'initialize',
+        args: [100, 123456],
+      });
+      if (!init.success || !init.result?.contract_id) return false;
+      const contractId = init.result.contract_id;
+      const total = await contractsApi.execute({
+        contract_id: contractId,
+        method_name: 'get_total',
+        method_type: 'view',
+        args: [],
+      });
+      const contrib = await contractsApi.execute({
+        contract_id: contractId,
+        method_name: 'get_contribution',
+        method_type: 'view',
+        args: ['a1b2c3d4e5f6789012345678901234567890abcdef12345678'],
+      });
+      return total.success && typeof total.result === 'number' &&
+        contrib.success && typeof contrib.result === 'number';
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- add Crowdfund tutorial steps guiding contract creation
- implement Walkthrough component that compiles code and validates each step
- expose walkthrough at /walkthrough route
- show final deployment screen with blueprint ID and copy helpers, plus review instructions
- integrate code editor and console into walkthrough so users can edit and run step tests directly

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b0ba6c5ef48321a2f4ca798f678840